### PR TITLE
Feature/make archive

### DIFF
--- a/index.php
+++ b/index.php
@@ -3,11 +3,16 @@
     <main class="blog_page pb-10">
         <div class="blog_content_wrapper inner flex">
             <div class="blog_wrapper">
-                <div class="archive_title">
-                  <p class="txt-14">blog</p>
-                  <h1 class="txt-24">ブログ</h1>
-                </div>
-                <div class="archive_desc txt-16">駆け出しの猟師としても活動する「カイロプラクティックどんぐり」管理人のブログです。主に猟師の活動、伊賀市などについて発信していきます。</div>
+                <?php if(is_date()): ?>
+                    <div class="archive_title">
+                        <h1 class="txt-24"><?php echo get_query_var('year'); ?>年</h1>
+                    </div>
+                <?php elseif(is_category()): ?>
+                    <div class="archive_title">
+                        <h1 class="txt-24">カテゴリ: <?php echo get_queried_object()->name ?></h1>
+                    </div>
+                    <div class="archive_desc txt-16">「<?php echo get_queried_object()->name ?>」に関する記事の一覧です。</div>
+                <?php endif; ?>
                 <?php if(have_posts()): ?>
                     <section class="article_lists">
                     <?php while(have_posts()): the_post(); ?>

--- a/index.php
+++ b/index.php
@@ -1,21 +1,41 @@
+<!-- ブログの記事一覧ページ -->
 <?php get_header(); ?>
     <main class="blog_page pb-10">
-        <div class="blog-wrapper">
-            <?php if(have_posts()): ?>
-                <?php while(have_posts()): the_post(); ?>
-                    <div class="post inner">
-                    <h1 class="post-title"><?php the_title(); ?></h1>
-                    <div class="post-content">
-                        <?php the_content(); ?>
-                    </div>
-                    </div>
-                <?php endwhile; ?>
+        <div class="blog_content_wrapper inner flex">
+            <div class="blog_wrapper">
+                <div class="archive_title">
+                  <p class="txt-14">blog</p>
+                  <h1 class="txt-24">ブログ</h1>
+                </div>
+                <div class="archive_desc txt-16">駆け出しの猟師としても活動する「カイロプラクティックどんぐり」管理人のブログです。主に猟師の活動、伊賀市などについて発信していきます。</div>
+                <?php if(have_posts()): ?>
+                    <section class="article_lists">
+                    <?php while(have_posts()): the_post(); ?>
+                        <article class="article_card">
+                            <a href="<?php the_permalink(); ?>" class="card">
+                                <!-- リンクカードのサムネイル画像 -->
+                                <div class="card_pic">
+                                    <?php if(has_post_thumbnail()): ?>
+                                        <?php the_post_thumbnail('thumbnail'); ?>
+                                    <?php else: ?>
+                                      <img src="<?php echo get_template_directory_uri(); ?>/img/noimage.jpg" alt="">
+                                    <?php endif; ?>
+                                </div>
+                                <!-- リンクカードのテキストグループ -->
+                                <div class="card_body">
+                                    <time datetime="<?php the_time('Y-m-d'); ?>" class="txt-14"><?php the_time('Y年m月d日') ?></time>
+                                    <h2 class="card_title txt-16"><?php the_title(); ?></h2>
+                                </div>
+                            </a>
+                        </article>
+                    <?php endwhile; ?>
+                    </section>
                 <?php else: ?>
                     <p>記事がありません</p>
-                <?php endif; ?>         
-        </div>
-
-        <!-- サイドバーのテンプレートの読み込み -->
-        <?php get_sidebar(); ?>        
+                <?php endif; ?>
+            </div>
+            <!-- サイドバーのテンプレートの読み込み -->
+            <?php get_sidebar(); ?>
+        </div>        
     <!-- mainの閉じタグはfooter.phpにある -->
 <?php get_footer(); ?>

--- a/sidebar.php
+++ b/sidebar.php
@@ -10,12 +10,12 @@
               <?php endif; ?>
           </div>
           <div class="profile_textarea">
-              <p class="profile_name txt-center">喜多 柊人</p>
+              <p class="profile_name txt-center txt-18">喜多 柊人</p>
               <p class="profile_desc txt-16">伊勢市出身、在住のカイロプラクター。副業として山に入り、猟をすることも。主なエリアは伊勢市や鳥羽市、伊賀市。</p>
           </div>
     </div>
     <div class="sidebar_item new_posts">
-          <p class="new_posts_header txt-center">新着記事</p>
+          <p class="new_posts_header txt-center txt-18">新着記事</p>
           <?php
           $args = array(
             'post_type' => 'post',


### PR DESCRIPTION
カテゴリや年でフィルタリングされた記事一覧ページを作成しました。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: template-only changes to WordPress theme rendering (archive headers and card layout) with no new data writes or security-sensitive logic.
> 
> **Overview**
> Updates `index.php` to render archive-aware blog listings: shows a year header for date archives and a category title/description for category archives, and switches the post loop to a card-based list with thumbnail fallback, date, and title.
> 
> Adjusts layout wrappers to place the sidebar alongside the listing, and tweaks `sidebar.php` typography classes (adds `txt-18` to profile name and “新着記事” header).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 328e8afc5f0d2af0143482519cef5b42533ad0c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->